### PR TITLE
Add scripts to scriptlauncher

### DIFF
--- a/import_docx.sh
+++ b/import_docx.sh
@@ -16,18 +16,16 @@ process() {
 	# fix lang code for ga -> gl
 	[ "$lang" = 'ga' ] && lang='gl'
 
-	step "Processing language $lang"
+	step "Processing language $lang in $2"
 
-	pandoc "$1" -o $lang.md --columns 80000 -t gfm-raw_html	
+	pandoc "$1" -o "$2"/$lang.md --columns 80000 -t gfm-raw_html
 
 	# Break paragraphs by phrases
-	sed -i 's/\([^0-9]\.\) /\1\n/g' $lang.md
+	sed -i 's/\([^0-9]\.\) /\1\n/g' "$2"/$lang.md
 	# Fix subscripts
-	sed -i 's/_(\([^)][^)]*\))/~\1~/g' $lang.md
+	sed -i 's/_(\([^)][^)]*\))/~\1~/g' "$2"/$lang.md
 }
 
-for a in "$@"; do
-	process "$a"
-done
+process "$@"
 
 

--- a/legaltexts/translate.py
+++ b/legaltexts/translate.py
@@ -1,12 +1,13 @@
 import yaml
 from pathlib import Path
-from importlib.resources import files as package_files
 
 def build_translations():
     if hasattr(build_translations, "translations"):
         return build_translations.translations
     translations = {}
-    for translation_file_name in package_files('legaltexts.i18n').iterdir():
+    pathlist = Path('legaltexts').glob('**/*.yaml')
+    print(pathlist)
+    for translation_file_name in pathlist:
         if translation_file_name.suffix != '.yaml': continue
         lang = translation_file_name.stem
         translations[lang] = yaml.safe_load(open(translation_file_name, 'r'))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+PyYAML
+typer
+consolemsg
+somutils
+pytest-cov
+beautifulsoup4

--- a/scriptlauncher.yaml
+++ b/scriptlauncher.yaml
@@ -12,10 +12,10 @@ legaltexts:
         docx:
           description: Introdueix el nom del fitxer docx a processar.
         folder:
-          description: Introdueix el non de la carpeta on es guardarà el fitxer md. Aquesta carpeta ha de existir en el repositori!!.
+          description: Introdueix el nom de la carpeta on es guardarà el fitxer md. Aquesta carpeta ha de existir en el repositori!!.
 
     legal-text-processor-extract:
-      script: /home/marite/.pyenv/versions/3.11.7/bin/python SOME_SRC/legal-texts/legaltexts/cli.py extract SOME_SRC/legal-texts/{folder}/{md}
+      script: /home/somenergia/.pyenv/versions/3.11.7/bin/python SOME_SRC/legal-texts/legaltexts/cli.py extract SOME_SRC/legal-texts/{folder}/{md}
       title: Extraer traduccions en format yaml
       description: >
         Extrear la correspondiente traducció segons el fitxer md
@@ -23,10 +23,10 @@ legaltexts:
         md:
           description: Introdueix el nom del fitxer md a processar.
         folder:
-          description: Introdueix el non de la carpeta on es guardarà el fitxer md. Aquesta carpeta ha de existir en el repositori!!.
+          description: Introdueix el nom de la carpeta on es guardarà el fitxer md. Aquesta carpeta ha de existir en el repositori!!.
 
     legal-text-processor-template:
-      script: /home/marite/.pyenv/versions/3.11.7/bin/python SOME_SRC/legal-texts/legaltexts/cli.py template SOME_SRC/legal-texts/{folder}/{md}
+      script: /home/somenergia/.pyenv/versions/3.11.7/bin/python SOME_SRC/legal-texts/legaltexts/cli.py template SOME_SRC/legal-texts/{folder}/{md}
       title: Extraer plantilla
       description: >
         Extraer plantilla amb claus de paragraphs a traduir
@@ -34,10 +34,10 @@ legaltexts:
         md:
           description: Introdueix el nom del fitxer md a processar.
         folder:
-          description: Introdueix el non de la carpeta on es guardarà el fitxer md. Aquesta carpeta ha de existir en el repositori!!.
+          description: Introdueix el nom de la carpeta on es guardarà el fitxer md. Aquesta carpeta ha de existir en el repositori!!.
 
     legal-text-processor-reintegrate:
-      script: /home/marite/.pyenv/versions/3.11.7/bin/python SOME_SRC/legal-texts/legaltexts/cli.py reintegrate SOME_SRC/legal-texts/{folder}/{yaml}
+      script: /home/somenergia/.pyenv/versions/3.11.7/bin/python SOME_SRC/legal-texts/legaltexts/cli.py reintegrate SOME_SRC/legal-texts/{folder}/{yaml}
       title: Reintegrar traduccions
       description: >
         Una vegada fetes les traduccions aquest script regenera els fitxer md corresponent a la traducció utilitzant la plantilla de paragraphs.
@@ -45,10 +45,10 @@ legaltexts:
         yaml:
           description: Introdueix el nom del fitxer yaml a processar.
         folder:
-          description: Introdueix el non de la carpeta on es guardarà el fitxer md. Aquesta carpeta ha de existir en el repositori!!.
+          description: Introdueix el nom de la carpeta on es guardarà el fitxer md. Aquesta carpeta ha de existir en el repositori!!.
 
     legal-text-processor-generate:
-      script: /home/marite/.pyenv/versions/3.11.7/bin/python SOME_SRC/legal-texts/legaltexts/cli.py generate SOME_SRC/legal-texts/{input_dir} --output-prefix={output-prefix} --target-type={target-type} {with-toc}
+      script: /home/somenergia/.pyenv/versions/3.11.7/bin/python SOME_SRC/legal-texts/legaltexts/cli.py generate SOME_SRC/legal-texts/{input_dir} --output-prefix={output-prefix} --target-type={target-type} {with-toc}
       title: Generar documents de sortida
       description: >
         Genera els documents de sortida en pdf o html en el directory 'output' per a totes les traduccions presents (fitxers {language}.yaml) en la carpeta del document.

--- a/scriptlauncher.yaml
+++ b/scriptlauncher.yaml
@@ -1,0 +1,71 @@
+legaltexts:
+
+  description: Legal texts process
+  scripts:
+
+    import-docxs:
+      script: SOME_SRC/legal-texts/import_docx.sh {docx} SOME_SRC/legal-texts/{folder}
+      title: Import docx a md
+      description: >
+        Import fitxers docx a md
+      parameters:
+        docx:
+          description: Introdueix el nom del fitxer docx a processar.
+        folder:
+          description: Introdueix el non de la carpeta on es guardarà el fitxer md. Aquesta carpeta ha de existir en el repositori!!.
+
+    legal-text-processor-extract:
+      script: /home/marite/.pyenv/versions/3.11.7/bin/python SOME_SRC/legal-texts/legaltexts/cli.py extract SOME_SRC/legal-texts/{folder}/{md}
+      title: Extraer traduccions en format yaml
+      description: >
+        Extrear la correspondiente traducció segons el fitxer md
+      parameters:
+        md:
+          description: Introdueix el nom del fitxer md a processar.
+        folder:
+          description: Introdueix el non de la carpeta on es guardarà el fitxer md. Aquesta carpeta ha de existir en el repositori!!.
+
+    legal-text-processor-template:
+      script: /home/marite/.pyenv/versions/3.11.7/bin/python SOME_SRC/legal-texts/legaltexts/cli.py template SOME_SRC/legal-texts/{folder}/{md}
+      title: Extraer plantilla
+      description: >
+        Extraer plantilla amb claus de paragraphs a traduir
+      parameters:
+        md:
+          description: Introdueix el nom del fitxer md a processar.
+        folder:
+          description: Introdueix el non de la carpeta on es guardarà el fitxer md. Aquesta carpeta ha de existir en el repositori!!.
+
+    legal-text-processor-reintegrate:
+      script: /home/marite/.pyenv/versions/3.11.7/bin/python SOME_SRC/legal-texts/legaltexts/cli.py reintegrate SOME_SRC/legal-texts/{folder}/{yaml}
+      title: Reintegrar traduccions
+      description: >
+        Una vegada fetes les traduccions aquest script regenera els fitxer md corresponent a la traducció utilitzant la plantilla de paragraphs.
+      parameters:
+        yaml:
+          description: Introdueix el nom del fitxer yaml a processar.
+        folder:
+          description: Introdueix el non de la carpeta on es guardarà el fitxer md. Aquesta carpeta ha de existir en el repositori!!.
+
+    legal-text-processor-generate:
+      script: /home/marite/.pyenv/versions/3.11.7/bin/python SOME_SRC/legal-texts/legaltexts/cli.py generate SOME_SRC/legal-texts/{input_dir} --output-prefix={output-prefix} --target-type={target-type} {with-toc}
+      title: Generar documents de sortida
+      description: >
+        Genera els documents de sortida en pdf o html en el directory 'output' per a totes les traduccions presents (fitxers {language}.yaml) en la carpeta del document.
+      parameters:
+        input_dir:
+          description: Carpeta on es troben totes les traduccions (fitxers yaml, per exemple es.yaml, ca.yaml, ...).
+        output-prefix:
+          description: Prefix pels fitxers de sortida.
+          default: 'output'
+        target-type:
+          description: html o pdf
+          default: 'html'
+        with-toc:
+          description: Afegeixe un index d'items. SOLAMENT per a fitxers html. L'index es generat automàticamnet NOMES si el placeholder TABLE es present en el fitxer yaml. 
+          type: enum
+          options:
+            Amb index: --with-toc
+            Sense index: --no-with-toc
+          default: --no-with-toc
+


### PR DESCRIPTION
## Description

Add scripts to scriptlauncher for generate html or pdf outputs with translations 

## Changes

- Add scriptlauncher.yaml 
- Addapt scripts to be executed in Python 2 and 3
- Remove remaining yamlns references
- Add requirements.txt 
